### PR TITLE
Add PySide2/PySide6 dual support, dark theme UI overhaul, and auto-re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A simple yet powerful tool for authoring USD (Universal Scene Description) edits
 
 - Autodesk Maya 2022+ with MayaUSD plugin
 - Python 3.7+
-- PySide2
+- PySide2 (Maya 2025 and earlier) or PySide6 (Maya 2026+)
 
 ## Installation
 
@@ -132,6 +132,8 @@ maya-usd-author/
 ├── scripts/
 │   └── maya_usd_editor/
 │       ├── __init__.py          # Package entry point
+│       ├── qt_compat.py         # PySide2/PySide6 compatibility shim
+│       ├── style.py             # Centralized dark stylesheet
 │       ├── usdPrimEditorUI.py   # Main UI
 │       ├── usdTreeModel.py      # Tree data model
 │       ├── usdUtils.py          # USD utilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [project.optional-dependencies]

--- a/scripts/maya_usd_editor/constants.py
+++ b/scripts/maya_usd_editor/constants.py
@@ -1,6 +1,6 @@
 """Constants and configuration values for the USD Prim Editor."""
 
-from PySide2.QtGui import QColor
+from .qt_compat import QColor
 
 
 # Attribute color coding

--- a/scripts/maya_usd_editor/qt_compat.py
+++ b/scripts/maya_usd_editor/qt_compat.py
@@ -1,0 +1,29 @@
+"""Qt compatibility shim for PySide2/PySide6.
+
+Maya 2025 and earlier use PySide2, Maya 2026+ uses PySide6.
+In non-Maya environments, PySide6 is tried first, then PySide2.
+"""
+
+PYSIDE_VERSION = 0
+
+try:
+    import maya.cmds as _cmds
+    _maya_version = int(_cmds.about(version=True))
+    if _maya_version >= 2026:
+        from PySide6 import QtWidgets, QtCore, QtGui
+        from PySide6.QtGui import QColor
+        PYSIDE_VERSION = 6
+    else:
+        from PySide2 import QtWidgets, QtCore, QtGui
+        from PySide2.QtGui import QColor
+        PYSIDE_VERSION = 2
+except Exception:
+    # Non-Maya environment: try PySide6 first, then PySide2
+    try:
+        from PySide6 import QtWidgets, QtCore, QtGui
+        from PySide6.QtGui import QColor
+        PYSIDE_VERSION = 6
+    except ImportError:
+        from PySide2 import QtWidgets, QtCore, QtGui
+        from PySide2.QtGui import QColor
+        PYSIDE_VERSION = 2

--- a/scripts/maya_usd_editor/style.py
+++ b/scripts/maya_usd_editor/style.py
@@ -1,0 +1,213 @@
+"""Centralized dark stylesheet matching Maya's native look."""
+
+_STYLESHEET = """
+/* ── Global ── */
+QWidget {
+    background-color: #3a3a3a;
+    color: #cccccc;
+    font-size: 12px;
+}
+
+/* ── Group Boxes ── */
+QGroupBox {
+    border: 1px solid #555555;
+    border-radius: 4px;
+    margin-top: 8px;
+    padding-top: 14px;
+    font-weight: bold;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 2px 6px;
+    color: #dddddd;
+}
+
+/* ── Push Buttons ── */
+QPushButton {
+    background-color: #4a4a4a;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    padding: 4px 12px;
+    min-height: 20px;
+    color: #cccccc;
+}
+
+QPushButton:hover {
+    background-color: #525252;
+    border-color: #666666;
+}
+
+QPushButton:pressed {
+    background-color: #3a3a3a;
+}
+
+QPushButton:disabled {
+    background-color: #3a3a3a;
+    color: #666666;
+    border-color: #444444;
+}
+
+/* Primary accent button */
+QPushButton#primaryButton {
+    background-color: #5285a6;
+    border-color: #5285a6;
+    color: #ffffff;
+}
+
+QPushButton#primaryButton:hover {
+    background-color: #6295b6;
+}
+
+QPushButton#primaryButton:pressed {
+    background-color: #427596;
+}
+
+/* ── Combo Boxes ── */
+QComboBox {
+    background-color: #4a4a4a;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    padding: 3px 8px;
+    min-height: 20px;
+    color: #cccccc;
+}
+
+QComboBox:hover {
+    border-color: #666666;
+}
+
+QComboBox::drop-down {
+    border: none;
+    width: 20px;
+}
+
+QComboBox QAbstractItemView {
+    background-color: #4a4a4a;
+    border: 1px solid #555555;
+    selection-background-color: #5285a6;
+    color: #cccccc;
+}
+
+/* ── Tree View / Tree Widget ── */
+QTreeView, QTreeWidget {
+    background-color: #2b2b2b;
+    alternate-background-color: #323232;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    color: #cccccc;
+    selection-background-color: #5285a6;
+}
+
+QTreeView::item:hover, QTreeWidget::item:hover {
+    background-color: #3e3e3e;
+}
+
+QTreeView::item:selected, QTreeWidget::item:selected {
+    background-color: #5285a6;
+    color: #ffffff;
+}
+
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings {
+    border-image: none;
+}
+
+/* ── Header View ── */
+QHeaderView::section {
+    background-color: #3a3a3a;
+    border: 1px solid #555555;
+    padding: 4px 6px;
+    color: #cccccc;
+    font-weight: bold;
+}
+
+/* ── Splitter ── */
+QSplitter::handle {
+    background-color: #555555;
+}
+
+QSplitter::handle:horizontal {
+    width: 3px;
+}
+
+QSplitter::handle:vertical {
+    height: 3px;
+}
+
+/* ── Plain Text Edit ── */
+QPlainTextEdit {
+    background-color: #2b2b2b;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    color: #cccccc;
+    font-family: monospace;
+    font-size: 11px;
+}
+
+/* ── Scroll Bars ── */
+QScrollBar:vertical {
+    background-color: #2b2b2b;
+    width: 12px;
+    border: none;
+}
+
+QScrollBar::handle:vertical {
+    background-color: #555555;
+    border-radius: 4px;
+    min-height: 20px;
+    margin: 2px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: #666666;
+}
+
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0px;
+}
+
+QScrollBar:horizontal {
+    background-color: #2b2b2b;
+    height: 12px;
+    border: none;
+}
+
+QScrollBar::handle:horizontal {
+    background-color: #555555;
+    border-radius: 4px;
+    min-width: 20px;
+    margin: 2px;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background-color: #666666;
+}
+
+QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
+    width: 0px;
+}
+
+/* ── Labels ── */
+QLabel {
+    background-color: transparent;
+    color: #cccccc;
+}
+
+QLabel#dimLabel {
+    color: #888888;
+    font-style: italic;
+}
+"""
+
+
+def apply_stylesheet(widget):
+    """Apply the dark stylesheet to a widget and all its children.
+
+    Call once on the root widget; all children inherit the style.
+
+    Args:
+        widget: The root QWidget to style.
+    """
+    widget.setStyleSheet(_STYLESHEET)

--- a/scripts/maya_usd_editor/usdTreeModel.py
+++ b/scripts/maya_usd_editor/usdTreeModel.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from PySide2 import QtGui, QtCore
+from .qt_compat import QtGui, QtCore
 from pxr import Usd
 
 from .usdUtils import get_prim_info, get_child_prims, PrimInfo, get_variant_sets, has_payload

--- a/scripts/maya_usd_editor/widgets/attribute_editor.py
+++ b/scripts/maya_usd_editor/widgets/attribute_editor.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Callable, Optional
 
-from PySide2 import QtWidgets, QtCore, QtGui
+from ..qt_compat import QtWidgets, QtCore, QtGui
 from pxr import Usd, Sdf, UsdGeom, Gf
 
 from ..constants import AttributeColors
@@ -45,28 +45,34 @@ class AttributeEditor(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Header
-        layout.addWidget(QtWidgets.QLabel("Attributes and Primvars:"))
+        group = QtWidgets.QGroupBox("Attributes & Primvars")
+        group_layout = QtWidgets.QVBoxLayout(group)
+        group_layout.setContentsMargins(6, 6, 6, 6)
+        group_layout.setSpacing(6)
 
         # Tree widget
         self.tree = QtWidgets.QTreeWidget()
         self.tree.setHeaderLabels(["Name", "Value"])
         self.tree.setItemDelegate(ColorCodedItemDelegate())
         self.tree.setAlternatingRowColors(True)
-        layout.addWidget(self.tree)
+        group_layout.addWidget(self.tree)
 
         # Buttons
         button_layout = QtWidgets.QHBoxLayout()
         self.add_attr_btn = QtWidgets.QPushButton("Add Attribute")
         self.add_primvar_btn = QtWidgets.QPushButton("Add Primvar")
-        self.edit_btn = QtWidgets.QPushButton("Edit")
-        self.remove_btn = QtWidgets.QPushButton("Remove")
 
         button_layout.addWidget(self.add_attr_btn)
         button_layout.addWidget(self.add_primvar_btn)
+        button_layout.addStretch()
+
+        self.edit_btn = QtWidgets.QPushButton("Edit")
+        self.remove_btn = QtWidgets.QPushButton("Remove")
         button_layout.addWidget(self.edit_btn)
         button_layout.addWidget(self.remove_btn)
-        layout.addLayout(button_layout)
+        group_layout.addLayout(button_layout)
+
+        layout.addWidget(group)
 
     def _connect_signals(self) -> None:
         """Connect internal signals."""

--- a/scripts/maya_usd_editor/widgets/payload_controls.py
+++ b/scripts/maya_usd_editor/widgets/payload_controls.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from PySide2 import QtWidgets, QtCore
+from ..qt_compat import QtWidgets, QtCore
 from pxr import Usd
 
 from ..usdUtils import has_payload, load_payload, unload_payload
@@ -28,20 +28,24 @@ class PayloadControls(QtWidgets.QWidget):
 
     def _setup_ui(self) -> None:
         """Set up the widget UI."""
-        layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout = QtWidgets.QVBoxLayout(self)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
 
-        layout.addWidget(QtWidgets.QLabel("Payload:"))
+        group = QtWidgets.QGroupBox("Payloads")
+        layout = QtWidgets.QHBoxLayout(group)
+        layout.setContentsMargins(6, 6, 6, 6)
+        layout.setSpacing(6)
 
-        self.load_btn = QtWidgets.QPushButton("Load")
+        self.load_btn = QtWidgets.QPushButton("Load Payload")
         self.load_btn.setEnabled(False)
         layout.addWidget(self.load_btn)
 
-        self.unload_btn = QtWidgets.QPushButton("Unload")
+        self.unload_btn = QtWidgets.QPushButton("Unload Payload")
         self.unload_btn.setEnabled(False)
         layout.addWidget(self.unload_btn)
 
         layout.addStretch()
+        outer_layout.addWidget(group)
 
     def _connect_signals(self) -> None:
         """Connect internal signals."""

--- a/scripts/maya_usd_editor/widgets/time_samples_editor.py
+++ b/scripts/maya_usd_editor/widgets/time_samples_editor.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Optional
 
-from PySide2 import QtWidgets, QtCore
+from ..qt_compat import QtWidgets, QtCore
 from pxr import Usd, Sdf, Gf
 
 logger = logging.getLogger(__name__)

--- a/scripts/maya_usd_editor/widgets/variant_editor.py
+++ b/scripts/maya_usd_editor/widgets/variant_editor.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from PySide2 import QtWidgets, QtCore
+from ..qt_compat import QtWidgets, QtCore
 from pxr import Usd
 
 from ..usdUtils import get_variant_sets, set_variant_selection
@@ -31,15 +31,12 @@ class VariantEditor(QtWidgets.QWidget):
         self._layout = QtWidgets.QVBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)
 
-        # Header label
-        self._header = QtWidgets.QLabel("Variant Sets:")
-        self._layout.addWidget(self._header)
-
-        # Container for dynamic variant set controls
-        self._variant_container = QtWidgets.QWidget()
-        self._variant_layout = QtWidgets.QVBoxLayout(self._variant_container)
-        self._variant_layout.setContentsMargins(0, 0, 0, 0)
-        self._layout.addWidget(self._variant_container)
+        # Group box replaces header label + container
+        self._group = QtWidgets.QGroupBox("Variant Sets")
+        self._variant_layout = QtWidgets.QVBoxLayout(self._group)
+        self._variant_layout.setContentsMargins(6, 6, 6, 6)
+        self._variant_layout.setSpacing(6)
+        self._layout.addWidget(self._group)
 
     def set_prim(self, prim: Optional[Usd.Prim]) -> None:
         """Set the current prim to display variant sets for.
@@ -61,7 +58,7 @@ class VariantEditor(QtWidgets.QWidget):
 
         if not variant_sets:
             no_variants_label = QtWidgets.QLabel("No variant sets")
-            no_variants_label.setStyleSheet("color: gray; font-style: italic;")
+            no_variants_label.setObjectName("dimLabel")
             self._variant_layout.addWidget(no_variants_label)
             return
 


### PR DESCRIPTION
…fresh on launch

- Add qt_compat.py shim: detects Maya version (>=2026 = PySide6, else PySide2) with fallback for non-Maya environments
- Add style.py: centralized Maya-matching dark stylesheet (#3a3a3a bg, #5285a6 accent, #cccccc text) applied once at root level
- Replace all direct PySide2 imports with qt_compat across 7 files
- Restructure main UI: QSplitter replaces flat QHBoxLayout, sections wrapped in QGroupBox (Stage Hierarchy, Prim Properties, Stage Layer, Attributes & Primvars, Variant Sets, Payloads), proper margins/spacing throughout
- Apply Changes button gets primary accent styling via objectName
- Rename payload buttons to "Load Payload" / "Unload Payload" for clarity
- Auto-refresh tree view on show so selected USD stage loads immediately
- Update README (PySide2/PySide6 requirements, new files in structure)
- Add Python 3.11 classifier to pyproject.toml